### PR TITLE
Adding support for document type messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,25 @@ Alternatively, you can also use a __reverse proxy__ like _nginx_ or [_Caddy_](ht
 ```
 {
 	"recipient_token": "3edf633a-eab0-45ea-9721-16c07bb8f245",
-	"text": "__Hello World!__ (yes, this is Markdown)",
+	"text": "*Hello World!* (yes, this is Markdown)",
+	"type": "TEXT",
 	"origin": "My lonely server script"
 }
 ```
+
+**NOTE:** If the field *type* is omitted then the `TEXT` type will be used as default, though this is not recommended as this may change in future versions.
+
+3. If you want to attach a file in the HTTP POST request you must encode it into a Base64 string and send it in a body like the following.
+
+```
+{
+	"recipient_token": "3edf633a-eab0-45ea-9721-16c07bb8f245",
+	"file": "SGVsbG8gV29ybGQhCg==",
+	"filename": "file.txt",
+	"type": "FILE",
+	"origin": "My lonely server script"
+}
+```
+
 ## License
 MIT @ [Ferdinand Mütsch](https://muetsch.io)

--- a/main.go
+++ b/main.go
@@ -79,6 +79,7 @@ func messageHandler(w http.ResponseWriter, r *http.Request) {
 	if invalid != nil {
 		w.WriteHeader(400)
 		w.Write([]byte(invalid.Error()))
+		return
 	}
 
 	recipientId := resolveToken(m.RecipientToken)
@@ -105,7 +106,7 @@ func messageHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	valueForStore  := typesResolvers[messageType].ValueForStore(m)
+	valueForStore  := typesResolvers[messageType].Value(m)
 	storedMessages := StoreGet(STORE_KEY_MESSAGES).(StoreMessageObject)
 	storedMessages = append(storedMessages, valueForStore)
 	StorePut(STORE_KEY_MESSAGES, storedMessages)

--- a/main.go
+++ b/main.go
@@ -32,20 +32,6 @@ func getApiUrl() string {
 	return BASE_URL + token
 }
 
-func sendMessage(recipientId, text string) error {
-	m, err := json.Marshal(&TelegramOutMessage{ChatId: recipientId, Text: text, ParseMode: "Markdown"})
-	if err != nil {
-		return err
-	}
-	reader := strings.NewReader(string(m))
-	resp, err := http.Post(getApiUrl()+"/sendMessage", "application/json", reader)
-	defer resp.Body.Close()
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 func invalidateUserToken(userChatId int) {
 	for k, v := range StoreGetMap() {
 		entry, ok := v.(StoreObject)
@@ -68,6 +54,7 @@ func messageHandler(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(415)
 		return
 	}
+
 	dec := json.NewDecoder(r.Body)
 	var m InMessage
 	err := dec.Decode(&m)
@@ -77,10 +64,21 @@ func messageHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(m.RecipientToken) == 0 || len(m.Text) == 0 || len(m.Origin) == 0 {
+	if len(m.RecipientToken) == 0 || len(m.Origin) == 0 {
 		w.WriteHeader(400)
-		w.Write([]byte("You need to pass recipient_token, origin and text parameters."))
+		w.Write([]byte("You need to pass recipient_token and origin."))
 		return
+	}
+
+	messageType := TEXT_TYPE
+	if len(m.Type) > 0 {
+		messageType = m.Type
+	}
+
+	invalid := typesResolvers[messageType].IsValid(m)
+	if invalid != nil {
+		w.WriteHeader(400)
+		w.Write([]byte(invalid.Error()))
 	}
 
 	recipientId := resolveToken(m.RecipientToken)
@@ -101,14 +99,15 @@ func messageHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	limiterMap[recipientId] += 1
 
-	err = sendMessage(recipientId, "*"+m.Origin+"* wrote:\n\n"+m.Text)
+	err = typesResolvers[messageType].Resolve(recipientId, m)
 	if err != nil {
 		w.WriteHeader(500)
 		return
 	}
 
+	valueForStore  := typesResolvers[messageType].ValueForStore(m)
 	storedMessages := StoreGet(STORE_KEY_MESSAGES).(StoreMessageObject)
-	storedMessages = append(storedMessages, m.Text)
+	storedMessages = append(storedMessages, valueForStore)
 	StorePut(STORE_KEY_MESSAGES, storedMessages)
 	StorePut(STORE_KEY_REQUESTS, StoreGet(STORE_KEY_REQUESTS).(int)+1)
 
@@ -243,6 +242,7 @@ func toJson(filePath string, data interface{}) {
 
 func main() {
 	InitStore()
+	InitResolvers()
 	ReadStoreFromBinary(STORE_FILE)
 
 	go func() {

--- a/model.go
+++ b/model.go
@@ -17,9 +17,9 @@ type InMessage struct {
 }
 
 type TypeResolver struct {
-	IsValid       func(InMessage) error
-	Resolve       func(string, InMessage) error
-	ValueForStore func(InMessage) string
+	IsValid func(InMessage) error
+	Resolve func(string, InMessage) error
+	Value   func(InMessage) string
 }
 
 // Only required fields are implemented

--- a/model.go
+++ b/model.go
@@ -11,11 +11,20 @@ type InMessage struct {
 	RecipientToken string `json:"recipient_token"`
 	Text           string `json:"text"`
 	Origin         string `json:"origin"`
+	File           string `json:"file"`
+	Filename       string `json:"filename"`
+	Type           string `json:"type"`
+}
+
+type TypeResolver struct {
+	IsValid       func(InMessage) error
+	Resolve       func(string, InMessage) error
+	ValueForStore func(InMessage) string
 }
 
 // Only required fields are implemented
 type TelegramUser struct {
-	Id        int    `json:"id`
+	Id        int    `json:"id"`
 	FirstName string `json:"first_name"`
 	LastName  string `json:"last_name"`
 	Username  string `json:"username"`
@@ -23,7 +32,7 @@ type TelegramUser struct {
 
 // Only required fields are implemented
 type TelegramChat struct {
-	Id   int    `json:"id`
+	Id   int    `json:"id"`
 	Type string `json:"type"`
 }
 

--- a/resolvers.go
+++ b/resolvers.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"mime/multipart"
+	"strings"
+	b64 "encoding/base64"
+	"bytes"
+	"io"
+	errors "errors"
+)
+
+const TEXT_TYPE = "TEXT"
+const FILE_TYPE = "FILE"
+var typesResolvers map[string] TypeResolver
+
+func InitResolvers() {
+	typesResolvers = map[string] TypeResolver {
+		TEXT_TYPE: TypeResolver{
+			Resolve:       sendMessageClosure,
+			IsValid:       sendMessageValidation,
+			ValueForStore: sendMessageValueForStore,
+		},
+		FILE_TYPE: TypeResolver{
+			Resolve:       sendFileClosure,
+			IsValid:       sendDocumentValidation,
+			ValueForStore: sendDocumentValueForStore,
+		},
+	}
+}
+
+// Send Message validaiton and resolving
+func sendMessageValidation(m InMessage) error {
+	if len(m.Text) == 0 {
+		return errors.New("You need to pass a text parameter")
+	}
+	return nil
+}
+
+func sendMessageValueForStore(m InMessage) string {
+	return m.Text
+}
+
+func sendMessageClosure(recipientId string, m InMessage) error {
+	return sendMessage(recipientId, "*"+m.Origin+"* wrote:\n\n"+m.Text)
+}
+
+func sendMessage(recipientId, text string) error {
+	m, err := json.Marshal(&TelegramOutMessage{ChatId: recipientId, Text: text, ParseMode: "Markdown"})
+	if err != nil {
+		return err
+	}
+	reader := strings.NewReader(string(m))
+	resp, err := http.Post(getApiUrl()+"/sendMessage", "application/json", reader)
+	defer resp.Body.Close()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Send Document validation and resolving
+func sendDocumentValidation(m InMessage) error {
+	if len(m.File) == 0 || len(m.Filename) == 0 {
+		return errors.New("You need to pass a file and filename parameter")
+	}
+	return nil
+}
+
+func sendDocumentValueForStore(m InMessage) string {
+	return "A document named " + m.Filename + " was sent"
+}
+
+func sendFileClosure(recipientId string, m InMessage) error {
+	decodedFile := decodeB64StringToByteArray(m.File)
+	return sendFile(recipientId, decodedFile, m.Filename, m.Origin)
+}
+
+func decodeB64StringToByteArray(encodedString string) []byte {
+	decodedString, _ := b64.StdEncoding.DecodeString(encodedString)
+	return decodedString
+}
+
+func sendFile(recipientId string, file []byte, filename string, origin string) error {
+	body := &bytes.Buffer{}
+	multipartWriter := multipart.NewWriter(body)
+	params := map[string]string {
+		"caption": "*" + origin + "* sent a document",
+		"parse_mode": "Markdown",
+	}
+	addFileAndParamsToMultipartWriter(multipartWriter, file, filename, params)
+	req, err := http.NewRequest("POST", getApiUrl()+"/sendDocument?chat_id=" + recipientId, body)
+	req.Header.Add("Content-Type", multipartWriter.FormDataContentType())
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	defer resp.Body.Close()
+
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func addFileAndParamsToMultipartWriter(multipartWriter *multipart.Writer, file []byte, filename string, params map[string]string) {
+	reader := bytes.NewReader(file)
+	part, _ := multipartWriter.CreateFormFile("document", filename)
+	io.Copy(part, reader)
+	for key, val := range params {
+		multipartWriter.WriteField(key, val)
+	}
+	multipartWriter.Close()
+}

--- a/resolvers.go
+++ b/resolvers.go
@@ -18,31 +18,31 @@ var typesResolvers map[string] TypeResolver
 func InitResolvers() {
 	typesResolvers = map[string] TypeResolver {
 		TEXT_TYPE: TypeResolver{
-			Resolve:       sendMessageClosure,
-			IsValid:       sendMessageValidation,
-			ValueForStore: sendMessageValueForStore,
+			Resolve: resolveText,
+			IsValid: validateText,
+			Value:   logText,
 		},
 		FILE_TYPE: TypeResolver{
-			Resolve:       sendFileClosure,
-			IsValid:       sendDocumentValidation,
-			ValueForStore: sendDocumentValueForStore,
+			Resolve: resolveFile,
+			IsValid: validateFile,
+			Value:   logFile,
 		},
 	}
 }
 
 // Send Message validaiton and resolving
-func sendMessageValidation(m InMessage) error {
+func validateText(m InMessage) error {
 	if len(m.Text) == 0 {
 		return errors.New("You need to pass a text parameter")
 	}
 	return nil
 }
 
-func sendMessageValueForStore(m InMessage) string {
+func logText(m InMessage) string {
 	return m.Text
 }
 
-func sendMessageClosure(recipientId string, m InMessage) error {
+func resolveText(recipientId string, m InMessage) error {
 	return sendMessage(recipientId, "*"+m.Origin+"* wrote:\n\n"+m.Text)
 }
 
@@ -61,18 +61,18 @@ func sendMessage(recipientId, text string) error {
 }
 
 // Send Document validation and resolving
-func sendDocumentValidation(m InMessage) error {
+func validateFile(m InMessage) error {
 	if len(m.File) == 0 || len(m.Filename) == 0 {
 		return errors.New("You need to pass a file and filename parameter")
 	}
 	return nil
 }
 
-func sendDocumentValueForStore(m InMessage) string {
+func logFile(m InMessage) string {
 	return "A document named " + m.Filename + " was sent"
 }
 
-func sendFileClosure(recipientId string, m InMessage) error {
+func resolveFile(recipientId string, m InMessage) error {
 	decodedFile := decodeB64StringToByteArray(m.File)
 	return sendFile(recipientId, decodedFile, m.Filename, m.Origin)
 }


### PR DESCRIPTION
## Features
### Support for sending attached files added
The users can now send files that will be translated into push messages of type document.
For this feature three new fields in the `InMessage` structure were added:
* type: Indicates the type of message that the user is sending. At the moment, it can be whether `TEXT` or `FILE` . If none is provided then the `TEXT` type will be used as default for backward compatibility.
* file: The file to send. To be able to pass it in the json along with the `RecipientToken` and `Origin` fields it should be encoded to Base64 which will be decoded in the resolver. (I used an online tool to encode the files)
* filename: The file's name and extension.

Example of a json for text message (it should work as usually):
```
{
	"recipient_token": "the-recipient-token",
	"type": "TEXT, // can be ommited as the TEXT type will be set as default
	"text": "__Hello World!__ (yes, this is Markdown)",
	"origin": "My lonely server script"
}
```
Example of a json for file message:
```
{
	"recipient_token": "the-recipient-token",
	"file": "dGVzdAo=",
	"filename": "file.txt",
	"type": "FILE",
	"origin": "My lonely server script"
}
```
By sending this you should receive and document type message with a file named "file.txt" with the content "test".

### Handler for the received types added
To achieve the previous feature a handler was needed to be implemented. It consists of a map which takes a string ("TEXT" or "FILE" for example) as key and returns a structure `TypeResolver`. This structure contains a reference to the functions needed to validate and translate the messages.

Maybe there are too many changes in this PR. Sorry for that!
Looking forward to your feedback :)