### PR TITLE
Added Bitbucket inlet for accepting webhooks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:alpine
+
+WORKDIR /data
+COPY . .
+RUN GO111MODULE=on go build -o output .
+
+FROM alpine
+
+WORKDIR /data
+COPY --from=0 /data/output /telegram-middleman-bot
+
+EXPOSE 8080
+ENTRYPOINT ["/telegram-middleman-bot"]

--- a/inlets/alertmanager.go
+++ b/inlets/alertmanager.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/n1try/telegram-middleman-bot/config"
-	"github.com/n1try/telegram-middleman-bot/model"
-	"github.com/n1try/telegram-middleman-bot/resolvers"
 	"net/http"
 	"regexp"
 	"strings"
+
+	"github.com/n1try/telegram-middleman-bot/config"
+	"github.com/n1try/telegram-middleman-bot/model"
+	"github.com/n1try/telegram-middleman-bot/resolvers"
 )
 
 var (
@@ -53,6 +54,7 @@ func (a AlertmanagerInlet) Middleware(next http.HandlerFunc) http.HandlerFunc {
 
 func transformMessage(in *model.AlertmanagerMessage, token string) *model.DefaultMessage {
 	var sb strings.Builder
+	sb.WriteString("*Alertmanager* wrote:\n\n")
 	for i, a := range in.Alerts {
 		// Status
 		var statusEmoji string
@@ -91,7 +93,6 @@ func transformMessage(in *model.AlertmanagerMessage, token string) *model.Defaul
 
 	return &model.DefaultMessage{
 		RecipientToken: token,
-		Origin:         "Alertmanager",
 		Type:           resolvers.TextType,
 		Text:           sb.String(),
 	}

--- a/inlets/bitbucket_webhook/bitbucket_webhook.go
+++ b/inlets/bitbucket_webhook/bitbucket_webhook.go
@@ -1,0 +1,153 @@
+package bitbucket_webhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/n1try/telegram-middleman-bot/config"
+	"github.com/n1try/telegram-middleman-bot/inlets"
+	"github.com/n1try/telegram-middleman-bot/model"
+	"github.com/n1try/telegram-middleman-bot/resolvers"
+)
+
+type BitbucketWebhookInlet struct {
+	inlets.Inlet
+}
+
+func New() inlets.Inlet {
+	return &BitbucketWebhookInlet{}
+}
+
+func (i *BitbucketWebhookInlet) Middleware(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		token := r.URL.Query().Get("token")
+		eventKey := r.Header.Get("X-Event-Key")
+
+		var payload Payload
+		j := json.NewDecoder(r.Body)
+		if err := j.Decode(&payload); err != nil {
+			w.WriteHeader(400)
+			w.Write([]byte(err.Error()))
+			return
+		}
+
+		message := &model.DefaultMessage{
+			RecipientToken: token,
+			Text:           buildMessage(eventKey, &payload),
+			Type:           resolvers.TextType,
+		}
+
+		ctx := r.Context()
+		ctx = context.WithValue(ctx, config.KeyMessage, message)
+		ctx = context.WithValue(ctx, config.KeyParams, &model.MessageParams{DisableLinkPreviews: true})
+
+		next(w, r.WithContext(ctx))
+	}
+}
+
+func buildMessage(eventKey string, payload *Payload) string {
+	switch eventKey {
+	// A user pushes 1 or more commits to a repository
+	case "repo:push":
+		fallthrough
+
+	// A user forks a repository
+	case "repo:fork":
+		fallthrough
+
+	// A user updates the  Name,  Description,  Website or Language fields
+	// under the Repository details page of the repository settings.
+	case "repo:updated":
+		fallthrough
+
+	// A repository transfer is accepted
+	case "repo:transfer":
+		fallthrough
+
+	// A user comments on a commit in a repository
+	case "repo:commit_comment_created":
+		fallthrough
+
+	// A build system, CI tool, or another vendor recognizes that
+	// a user recently pushed a commit and updates the commit with its status
+	case "repo:commit_status_created":
+		fallthrough
+
+	// A build system, CI tool, or another vendor recognizes that
+	// a commit has a new status and updates the commit with its status
+	case "repo:commit_status_updated":
+		if payload.CommitStatus != nil {
+			var emoji string
+			switch payload.CommitStatus.State {
+			case "INPROGRESS":
+				emoji = "⌛️"
+			case "SUCCESSFUL":
+				emoji = "✅"
+			case "FAILED":
+				emoji = "❌"
+			}
+			return fmt.Sprintf(
+				"%s *%s*: [%s](%s)\n%s",
+				emoji,
+				payload.Repository.Name,
+				payload.CommitStatus.State,
+				payload.CommitStatus.URL,
+				payload.CommitStatus.Name,
+			)
+		}
+		fallthrough
+
+	// A user creates an issue for a repository
+	case "issue:created":
+		fallthrough
+
+	// A user updated an issue for a repository
+	case "issue:updated":
+		fallthrough
+
+	// A user comments on an issue associated with a repository
+	case "issue:comment_created":
+		fallthrough
+
+	// A user creates a pull request for a repository
+	case "pullrequest:created":
+		fallthrough
+
+	// A user updates a pull request for a repository
+	case "pullrequest:updated":
+		fallthrough
+
+	// A user approves a pull request for a repository.
+	case "pullrequest:approved":
+		fallthrough
+
+	// A user removes an approval from a pull request for a repository
+	case "pullrequest:unapproved":
+		fallthrough
+
+	// A user merges a pull request for a repository
+	case "pullrequest:fulfilled":
+		fallthrough
+
+	// A user declines a pull request for a repository
+	case "pullrequest:rejected":
+		fallthrough
+
+	// A user comments on a pull request
+	case "pullrequest:comment_created":
+		fallthrough
+
+	// A user updates a comment on a pull request
+	case "pullrequest:comment_updated":
+		fallthrough
+
+	// A user deletes a comment on a pull request
+	case "pullrequest:comment_deleted":
+		fallthrough
+
+	default:
+		return fmt.Sprintf("Event %s triggered", eventKey)
+	}
+}

--- a/inlets/bitbucket_webhook/model.go
+++ b/inlets/bitbucket_webhook/model.go
@@ -1,0 +1,99 @@
+package bitbucket_webhook
+
+import "time"
+
+type Link struct {
+	Href string `json:"href"`
+}
+
+type Links struct {
+	Self    Link `json:"self"`
+	HTML    Link `json:"html"`
+	Avatar  Link `json:"avatar"`
+	Diff    Link `json:"diff"`
+	Commits Link `json:"commits"`
+}
+
+type User struct {
+	Type        string `json:"type"`
+	Username    string `json:"username"`
+	Nickname    string `json:"nickname"`
+	DisplayName string `json:"display_name"`
+	UUID        string `json:"uuid"`
+	Links       Links  `json:"links"`
+}
+
+type Project struct {
+	Type    string `json:"type"`
+	Project string `json:"project"`
+	UUID    string `json:"uuid"`
+	Links   Links  `json:"links"`
+	Key     string `json:"key"`
+}
+
+type Repository struct {
+	Type      string  `json:"type"`
+	Links     Links   `json:"links"`
+	UUID      string  `json:"uuid"`
+	Project   Project `json:"project"`
+	FullName  string  `json:"full_name"`
+	Name      string  `json:"name"`
+	Website   string  `json:"website"`
+	Owner     User    `json:"owner"`
+	Scm       string  `json:"scm"`
+	IsPrivate bool    `json:"is_private"`
+}
+
+type Payload struct {
+	Actor        User          `json:"actor"`
+	Repository   Repository    `json:"repository"`
+	CommitStatus *CommitStatus `json:"commit_status"`
+	Push         *Push         `json:"push"`
+	Fork         *Fork         `json:"fork"`
+}
+
+type CommitStatus struct {
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	State       string    `json:"state"`
+	Key         string    `json:"key"`
+	URL         string    `json:"url"`
+	Type        string    `json:"type"`
+	CreatedOn   time.Time `json:"created_on"`
+	UpdatedOn   time.Time `json:"updated_on"`
+	Links       Links     `json:"links"`
+}
+
+type Push struct {
+	Changes []Change `json:"changes"`
+}
+
+type Change struct {
+	New       State    `json:"new"`
+	Old       State    `json:"old"`
+	Links     Links    `json:"links"`
+	Created   bool     `json:"created"`
+	Forced    bool     `json:"forced"`
+	Closed    bool     `json:"closed"`
+	Commits   []Commit `json:"commits"`
+	Truncated bool     `json:"truncated"`
+}
+
+type State struct {
+	Type   string `json:"type"`
+	Name   string `json:"name"`
+	Target Commit `json:"target"`
+	Links  Links  `json:"links"`
+}
+
+type Commit struct {
+	Type    string    `json:"type"`
+	Hash    string    `json:"hash"`
+	Author  User      `json:"author"`
+	Message string    `json:"message"`
+	Date    time.Time `json:"date"`
+	Parents []Commit  `json:"parents"`
+	Links   Links     `json:"links"`
+}
+
+type Fork Repository

--- a/inlets/default.go
+++ b/inlets/default.go
@@ -3,9 +3,10 @@ package inlets
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+
 	"github.com/n1try/telegram-middleman-bot/config"
 	"github.com/n1try/telegram-middleman-bot/model"
-	"net/http"
 )
 
 type DefaultInlet struct{}
@@ -24,6 +25,14 @@ func (d DefaultInlet) Middleware(next http.HandlerFunc) http.HandlerFunc {
 			w.Write([]byte(err.Error()))
 			return
 		}
+
+		if len(m.Origin) == 0 {
+			w.WriteHeader(400)
+			w.Write([]byte("missing origin parameter"))
+			return
+		}
+
+		m.Text = "*" + m.Origin + "* wrote:\n\n" + m.Text
 
 		next(
 			w,

--- a/main.go
+++ b/main.go
@@ -2,14 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/n1try/telegram-middleman-bot/api"
-	"github.com/n1try/telegram-middleman-bot/config"
-	"github.com/n1try/telegram-middleman-bot/inlets"
-	"github.com/n1try/telegram-middleman-bot/middleware"
-	"github.com/n1try/telegram-middleman-bot/model"
-	"github.com/n1try/telegram-middleman-bot/resolvers"
-	"github.com/n1try/telegram-middleman-bot/store"
-	"github.com/n1try/telegram-middleman-bot/util"
 	"log"
 	"net"
 	"net/http"
@@ -18,6 +10,16 @@ import (
 	"strconv"
 	"syscall"
 	"time"
+
+	"github.com/n1try/telegram-middleman-bot/api"
+	"github.com/n1try/telegram-middleman-bot/config"
+	"github.com/n1try/telegram-middleman-bot/inlets"
+	"github.com/n1try/telegram-middleman-bot/inlets/bitbucket_webhook"
+	"github.com/n1try/telegram-middleman-bot/middleware"
+	"github.com/n1try/telegram-middleman-bot/model"
+	"github.com/n1try/telegram-middleman-bot/resolvers"
+	"github.com/n1try/telegram-middleman-bot/store"
+	"github.com/n1try/telegram-middleman-bot/util"
 )
 
 var (
@@ -46,9 +48,9 @@ func handleMessage(w http.ResponseWriter, r *http.Request) {
 		token = m.RecipientToken
 	}
 
-	if len(token) == 0 || len(m.Origin) == 0 {
+	if len(token) == 0 {
 		w.WriteHeader(400)
-		w.Write([]byte("missing recipient_token and origin parameters"))
+		w.Write([]byte("missing recipient_token parameter"))
 		return
 	}
 
@@ -116,6 +118,7 @@ func registerRoutes() {
 	http.HandleFunc("/api/messages", middleware.Chain(baseChain, inlets.NewDefaultInlet().Middleware))
 	http.HandleFunc("/api/inlets/default", middleware.Chain(baseChain, inlets.NewDefaultInlet().Middleware))
 	http.HandleFunc("/api/inlets/alertmanager", middleware.Chain(baseChain, inlets.NewAlertmanagerInlet().Middleware))
+	http.HandleFunc("/api/inlets/bitbucket_webhook", middleware.Chain(baseChain, bitbucket_webhook.New().Middleware))
 }
 
 func connectApi() {

--- a/resolvers/text.go
+++ b/resolvers/text.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"errors"
+
 	"github.com/n1try/telegram-middleman-bot/api"
 	"github.com/n1try/telegram-middleman-bot/model"
 )
@@ -25,7 +26,7 @@ func resolveText(recipientId string, m *model.DefaultMessage, params *model.Mess
 
 	return api.SendMessage(&model.TelegramOutMessage{
 		ChatId:             recipientId,
-		Text:               "*" + m.Origin + "* wrote:\n\n" + m.Text,
+		Text:               m.Text,
 		ParseMode:          "Markdown",
 		DisableLinkPreview: disableLinkPreview,
 	})


### PR DESCRIPTION
- Introduced a new inlet for accepting Bitbucket webhooks. For now only pipeline status change is supported, it lets you to be informed when new job has started or finished with success or error.

- Dockerfile for building an image

- I also made the Origin parameter is only required for Default inlet as I didn't like that its not possible to customise "XXX wrote:". Now its up to inlet to specify the origin in the message.