### PR TITLE
Escape input to not break markdown

### DIFF
--- a/inlets/alertmanager_webhook/alertmanager_webhook.go
+++ b/inlets/alertmanager_webhook/alertmanager_webhook.go
@@ -12,6 +12,7 @@ import (
 	"github.com/n1try/telegram-middleman-bot/inlets"
 	"github.com/n1try/telegram-middleman-bot/model"
 	"github.com/n1try/telegram-middleman-bot/resolvers"
+	"github.com/n1try/telegram-middleman-bot/util"
 )
 
 var (
@@ -78,6 +79,8 @@ func transformMessage(in *Message, token string) *model.DefaultMessage {
 		if len(a.Labels) > 0 {
 			sb.WriteString(fmt.Sprintf("*🏷 Labels:*\n"))
 			for k, v := range a.Labels {
+				k = util.EscapeMarkdown(k)
+				v = util.EscapeMarkdown(v)
 				sb.WriteString(fmt.Sprintf("– `%s` = `%s`\n", k, v))
 			}
 		}
@@ -86,6 +89,8 @@ func transformMessage(in *Message, token string) *model.DefaultMessage {
 		if len(a.Annotations) > 0 {
 			sb.WriteString(fmt.Sprintf("*📝 Annotations:*\n"))
 			for k, v := range a.Annotations {
+				k = util.EscapeMarkdown(k)
+				v = util.EscapeMarkdown(v)
 				sb.WriteString(fmt.Sprintf("– `%s` = `%s`\n", k, v))
 			}
 		}

--- a/inlets/default/default.go
+++ b/inlets/default/default.go
@@ -8,6 +8,7 @@ import (
 	"github.com/n1try/telegram-middleman-bot/config"
 	"github.com/n1try/telegram-middleman-bot/inlets"
 	"github.com/n1try/telegram-middleman-bot/model"
+	"github.com/n1try/telegram-middleman-bot/util"
 )
 
 type DefaultInlet struct {
@@ -35,7 +36,7 @@ func (i *DefaultInlet) Middleware(next http.HandlerFunc) http.HandlerFunc {
 			return
 		}
 
-		m.Text = "*" + m.Origin + "* wrote:\n\n" + m.Text
+		m.Text = "*" + util.EscapeMarkdown(m.Origin) + "* wrote:\n\n" + m.Text
 
 		next(
 			w,

--- a/util/util.go
+++ b/util/util.go
@@ -4,6 +4,15 @@ import (
 	"encoding/json"
 	"log"
 	"os"
+	"strings"
+)
+
+var markdownReplacer = strings.NewReplacer(
+	"\\", "\\\\",
+	"`", "\\`",
+	"*", "\\*",
+	"[", "\\[",
+	"_", "\\_",
 )
 
 func DumpJson(filePath string, data interface{}) {
@@ -19,4 +28,8 @@ func DumpJson(filePath string, data interface{}) {
 	if err != nil {
 		log.Println(err)
 	}
+}
+
+func EscapeMarkdown(s string) string {
+	return markdownReplacer.Replace(s)
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,21 @@
+package util
+
+import "testing"
+
+func TestEscapeMarkdown(t *testing.T) {
+	cases := []struct {
+		test     string
+		expected string
+	}{
+		{
+			"\\,`,*,{,},[,],(,),#,+,-,.,!,_,>",
+			"\\\\,\\`,\\*,{,},\\[,],(,),#,+,-,.,!,\\_,>",
+		},
+	}
+	for _, c := range cases {
+		actual := EscapeMarkdown(c.test)
+		if actual != c.expected {
+			t.Fatalf("%s != %s", actual, c.expected)
+		}
+	}
+}


### PR DESCRIPTION
I started using the Bitbucket inlet and realised that some strings coming from CI break the Markdown, so they need to be properly escaped before using as part of a Markdown message.